### PR TITLE
Fix cucumber

### DIFF
--- a/app/views/admin/index.html.erb
+++ b/app/views/admin/index.html.erb
@@ -17,7 +17,7 @@
         <th scope="col">First Name</th>
         <th scope="col">Last Name</th>
         <th scope="col">Email</th>
-        <th scope="col">Unit</th>
+        <th scope="col">Outfit</th>
         <th scope="col">Minor Unit</th>
         <th scope="col">Major Unit</th>
         <th scope="col" class="text-center align-middle">Actions</th>

--- a/features/notification_on_event.feature
+++ b/features/notification_on_event.feature
@@ -11,12 +11,12 @@ Scenario: Send email when creating a new event with all required details
 	Given the user is on the "New Training Activity" page
 	When the user fills in all required fields with event details
 	And the user submits the event creation form
-	Then an email should be sent to "dummy_minor_unit@tamu.edu"
+	Then an email should be sent to "dummy_minor_unit_staff@tamu.edu"
 
 
 Scenario: Creation email not sent to major unit
     Given the user is on the "New Training Activity" page
 	When the user fills in all required fields with event details
 	And the user submits the event creation form
-    Then an email should not be sent to "dummy_major_unit@tamu.edu"
+    Then an email should not be sent to "dummy_major_unit_staff@tamu.edu"
 

--- a/features/step_definitions/notification_steps.rb
+++ b/features/step_definitions/notification_steps.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
 Then('an email should be sent to {string}') do |email|
-  visit 'letter_opener'
-  expect(page).to have_text("To: #{email}")
+  user_id = ActiveJob::Base.queue_adapter.enqueued_jobs.last[:args][3]["args"][1]["_aj_globalid"].split("/").last
+  expect(User.find(user_id).email).to eq(email)
 end
 
 Then('an email should not be sent to {string}') do |email|
-  visit 'letter_opener'
-  expect(page).to_not have_text("To: #{email}")
+  user_id = ActiveJob::Base.queue_adapter.enqueued_jobs.last[:args][3]["args"][1]["_aj_globalid"].split("/").last
+  expect(User.find(user_id).email).to_not eq(email)
 end

--- a/features/step_definitions/notification_steps.rb
+++ b/features/step_definitions/notification_steps.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
 Then('an email should be sent to {string}') do |email|
-  user_id = ActiveJob::Base.queue_adapter.enqueued_jobs.last[:args][3]["args"][1]["_aj_globalid"].split("/").last
+  user_id = ActiveJob::Base.queue_adapter.enqueued_jobs.last[:args][3]['args'][1]['_aj_globalid'].split('/').last
   expect(User.find(user_id).email).to eq(email)
 end
 
 Then('an email should not be sent to {string}') do |email|
-  user_id = ActiveJob::Base.queue_adapter.enqueued_jobs.last[:args][3]["args"][1]["_aj_globalid"].split("/").last
+  user_id = ActiveJob::Base.queue_adapter.enqueued_jobs.last[:args][3]['args'][1]['_aj_globalid'].split('/').last
   expect(User.find(user_id).email).to_not eq(email)
 end

--- a/features/step_definitions/shared_steps.rb
+++ b/features/step_definitions/shared_steps.rb
@@ -6,43 +6,43 @@ Given('I am a user with name {string}') do |name|
   last_name = name_parts[1..].join(' ') # Joins the rest of the parts as the last name.
   email = "#{first_name.downcase}#{last_name.downcase}@tamu.edu"
 
-  cmdt = Unit.create!(name: 'Demo CMDT', cat: "cmdt")
+  cmdt = Unit.create!(name: 'Demo CMDT', cat: 'cmdt')
   major = Unit.create!(name: 'Demo Major', cat: 'major', parent: cmdt)
   minor = Unit.create!(name: 'Demo Minor', cat: 'minor', parent: major)
   outfit = Unit.create!(name: 'Demo Outfit', cat: 'outfit', parent: minor)
 
   # Create Staff for the minor, major and cmdt units
-  minor_unit_staff = User.find_or_create_by(email: "dummy_minor_unit_staff@tamu.edu") do |minor_unit_staff| 
-      minor_unit_staff.first_name = "Demo Minor",
-      minor_unit_staff.last_name = "Staff",
-      minor_unit_staff.provider = "google_oauth2", 
-      minor_unit_staff.unit = minor, 
-      minor_unit_staff.minor = "Demo Minor", 
-      minor_unit_staff.major = "Demo Major", 
-      minor_unit_staff.unit_name = "Demo Minor Staff", 
-      minor_unit_staff.admin_flag = false
+  User.find_or_create_by(email: 'dummy_minor_unit_staff@tamu.edu') do |minor_unit_staff|
+    minor_unit_staff.first_name = 'Demo Minor',
+                                  minor_unit_staff.last_name = 'Staff',
+                                  minor_unit_staff.provider = 'google_oauth2',
+                                  minor_unit_staff.unit = minor,
+                                  minor_unit_staff.minor = 'Demo Minor',
+                                  minor_unit_staff.major = 'Demo Major',
+                                  minor_unit_staff.unit_name = 'Demo Minor Staff',
+                                  minor_unit_staff.admin_flag = false
   end
 
-  major_unit_staff = User.find_or_create_by(email: "dummy_major_unit_staff@tamu.edu") do |major_unit_staff| 
-    major_unit_staff.first_name = "Demo Major",
-    major_unit_staff.last_name = "Staff",
-    major_unit_staff.provider = "google_oauth2", 
-    major_unit_staff.unit = major, 
-    major_unit_staff.minor = nil, 
-    major_unit_staff.major = "Demo Major", 
-    major_unit_staff.unit_name = "Demo Major Staff", 
-    major_unit_staff.admin_flag = false
+  User.find_or_create_by(email: 'dummy_major_unit_staff@tamu.edu') do |major_unit_staff|
+    major_unit_staff.first_name = 'Demo Major',
+                                  major_unit_staff.last_name = 'Staff',
+                                  major_unit_staff.provider = 'google_oauth2',
+                                  major_unit_staff.unit = major,
+                                  major_unit_staff.minor = nil,
+                                  major_unit_staff.major = 'Demo Major',
+                                  major_unit_staff.unit_name = 'Demo Major Staff',
+                                  major_unit_staff.admin_flag = false
   end
 
-  cmdt_staff = User.find_or_create_by(email: "dummy_cmdt_staff@tamu.edu") do |cmdt_staff| 
-      cmdt_staff.first_name = "Demo CMDT",
-      cmdt_staff.last_name = "Staff",
-      cmdt_staff.provider = "google_oauth2", 
-      cmdt_staff.unit = cmdt, 
-      cmdt_staff.minor = nil, 
-      cmdt_staff.major = nil, 
-      cmdt_staff.unit_name = "Demo CMDT Staff", 
-      cmdt_staff.admin_flag = false
+  User.find_or_create_by(email: 'dummy_cmdt_staff@tamu.edu') do |cmdt_staff|
+    cmdt_staff.first_name = 'Demo CMDT',
+                            cmdt_staff.last_name = 'Staff',
+                            cmdt_staff.provider = 'google_oauth2',
+                            cmdt_staff.unit = cmdt,
+                            cmdt_staff.minor = nil,
+                            cmdt_staff.major = nil,
+                            cmdt_staff.unit_name = 'Demo CMDT Staff',
+                            cmdt_staff.admin_flag = false
   end
 
   @user = User.find_or_create_by(email:) do |user|

--- a/features/step_definitions/shared_steps.rb
+++ b/features/step_definitions/shared_steps.rb
@@ -6,9 +6,44 @@ Given('I am a user with name {string}') do |name|
   last_name = name_parts[1..].join(' ') # Joins the rest of the parts as the last name.
   email = "#{first_name.downcase}#{last_name.downcase}@tamu.edu"
 
-  major = Unit.create(name: 'Demo Major', cat: 'major', email: 'dummy_major_unit@tamu.edu')
-  minor = Unit.create(name: 'Demo Minor', cat: 'minor', email: 'dummy_minor_unit@tamu.edu', parent: major)
-  outfit = Unit.create(name: 'Demo Outfit', cat: 'outfit', email: 'dummy_outfit_unit@tamu.edu', parent: minor)
+  cmdt = Unit.create!(name: 'Demo CMDT', cat: "cmdt")
+  major = Unit.create!(name: 'Demo Major', cat: 'major', parent: cmdt)
+  minor = Unit.create!(name: 'Demo Minor', cat: 'minor', parent: major)
+  outfit = Unit.create!(name: 'Demo Outfit', cat: 'outfit', parent: minor)
+
+  # Create Staff for the minor, major and cmdt units
+  minor_unit_staff = User.find_or_create_by(email: "dummy_minor_unit_staff@tamu.edu") do |minor_unit_staff| 
+      minor_unit_staff.first_name = "Demo Minor",
+      minor_unit_staff.last_name = "Staff",
+      minor_unit_staff.provider = "google_oauth2", 
+      minor_unit_staff.unit = minor, 
+      minor_unit_staff.minor = "Demo Minor", 
+      minor_unit_staff.major = "Demo Major", 
+      minor_unit_staff.unit_name = "Demo Minor Staff", 
+      minor_unit_staff.admin_flag = false
+  end
+
+  major_unit_staff = User.find_or_create_by(email: "dummy_major_unit_staff@tamu.edu") do |major_unit_staff| 
+    major_unit_staff.first_name = "Demo Major",
+    major_unit_staff.last_name = "Staff",
+    major_unit_staff.provider = "google_oauth2", 
+    major_unit_staff.unit = major, 
+    major_unit_staff.minor = nil, 
+    major_unit_staff.major = "Demo Major", 
+    major_unit_staff.unit_name = "Demo Major Staff", 
+    major_unit_staff.admin_flag = false
+  end
+
+  cmdt_staff = User.find_or_create_by(email: "dummy_cmdt_staff@tamu.edu") do |cmdt_staff| 
+      cmdt_staff.first_name = "Demo CMDT",
+      cmdt_staff.last_name = "Staff",
+      cmdt_staff.provider = "google_oauth2", 
+      cmdt_staff.unit = cmdt, 
+      cmdt_staff.minor = nil, 
+      cmdt_staff.major = nil, 
+      cmdt_staff.unit_name = "Demo CMDT Staff", 
+      cmdt_staff.admin_flag = false
+  end
 
   @user = User.find_or_create_by(email:) do |user|
     user.first_name = first_name

--- a/lib/assets/devroster.csv
+++ b/lib/assets/devroster.csv
@@ -7,4 +7,4 @@ Dev,Garg,,devgargd7@gmail.com,1REG,5BN,P2,P2,2027
 Manas,Sahu,,manas.sahu@tamu.edu,1REG,5BN,P2,P2,2027
 TestMinor,5BN,,testminor@tamu.edu,1REG,5BN,5BN Staff,P2,2027
 TestMajor,1REG,,testmajor@tamu.edu,1REG,,1REG Staff,P2,2027
-TestCMDT,CMDT,,testcmdt@tamu.edu,1REG,,CMDT Staff,CMDT Staff,2027
+TestCMDT,CMDT,,testcmdt@tamu.edu,,,CMDT Staff,CMDT Staff,2027

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -3,7 +3,7 @@
 FactoryBot.define do
   factory :unit do
     name { 'Dummy Outfit' }
-    cat { 'generic' }
+    cat { 'outfit' }
     email { 'dummy_outfit_email@email.email' }
     parent_id { nil }
   end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -51,6 +51,10 @@ RSpec.configure do |config|
     Rails.application.load_seed
   end
 
+  config.after(:suite) do 
+    DatabaseCleaner.clean_with(:truncation)
+  end
+
   config.include FactoryBot::Syntax::Methods
 
   # You can uncomment this line to turn off ActiveRecord support entirely.

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -51,7 +51,7 @@ RSpec.configure do |config|
     Rails.application.load_seed
   end
 
-  config.after(:suite) do 
+  config.after(:suite) do
     DatabaseCleaner.clean_with(:truncation)
   end
 


### PR DESCRIPTION
Fixed 2 failing cucumber tests

- approve_change_plan.feature failure was caused by the Unit FactoryBot having the "cat" value set to "generic" instead of "outfit". This caused an exception that required the "cat" to be "outfit".
- notification_on_event.feature failure was caused by the fact that emails are set to be delivered asynchronously. This means that when we checked the letter opener the email had not yet been sent. Instead the feature now checks the job buffer of the email and its sender.